### PR TITLE
Rename bme280 platform to bme280_i2c

### DIFF
--- a/Integrations/ESPHome/MSR-1.yaml
+++ b/Integrations/ESPHome/MSR-1.yaml
@@ -409,7 +409,7 @@ sensor:
       still_energy:
         name: g8 still energy
 
-  - platform: bme280
+  - platform: bme280_i2c
     id: bme_280
     temperature:
       name: "BME280 Temperature"

--- a/Integrations/ESPHome/MSR-1.yaml
+++ b/Integrations/ESPHome/MSR-1.yaml
@@ -1,7 +1,7 @@
 #Define Project
 substitutions:
   name: apollo-msr-1
-  version:  "24.1.10.1"
+  version:  "24.2.20.1"
   device_description: ${name} made by Apollo Automation - version ${version}.
   
 esphome:

--- a/Integrations/ESPHome/manifest.json
+++ b/Integrations/ESPHome/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "apollo-msr-1",
-    "version": "24.1.10.1",
+    "version": "24.2.20.1",
     "new_install_prompt_erase": false,
     "builds": [
       {


### PR DESCRIPTION
Checks:
- [ ] Documentation Updated
- [ ] Build Number Incremented In MSR-1.yaml
- [ ] Build Number Incremented In manifest.json
- [ ] firmware-factory.bin Updated

The following change was made and just released a few hours ago with esphome 2024.2.0. 
https://github.com/esphome/esphome/pull/5538