### PR TITLE
Fix Bluetooth YAML

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,6 +1,6 @@
 substitutions:
   name: apollo-msr-1
-  version:  "24.7.15.1"
+  version:  "25.2.20.1"
   device_description: ${name} made by Apollo Automation - version ${version}.
 
 esp32:

--- a/Integrations/ESPHome/MSR-1_BLE.yaml
+++ b/Integrations/ESPHome/MSR-1_BLE.yaml
@@ -26,9 +26,7 @@ ota:
   - platform: esphome
     password: "apolloautomation"
 
-
 wifi:
-  power_save_mode: none
   ap:
     ssid: "Apollo MSR1 Hotspot"
 
@@ -36,9 +34,4 @@ bluetooth_proxy:
   active: true
 
 packages:
-  remote_package:
-    url: https://github.com/ApolloAutomation/MSR-1/
-    ref: main
-    files:
-      - Integrations/ESPHome/Core.yaml
-    refresh: 0d
+  core: !include Core.yaml

--- a/Integrations/ESPHome/MSR-1_Factory.yaml
+++ b/Integrations/ESPHome/MSR-1_Factory.yaml
@@ -42,11 +42,5 @@ ota:
   - platform: esphome
     id: ota_esphome
 
-
 packages:
-  remote_package:
-    url: https://github.com/ApolloAutomation/MSR-1/
-    ref: main
-    files:
-      - Integrations/ESPHome/Core.yaml
-    refresh: 0d
+  core: !include Core.yaml


### PR DESCRIPTION
Version: 25.2.20.1

Adds:

Fixes:
- Bluetooth YAML

Breaks:



Checks:
- [ ] Documentation Updated
- [ ] Build Number Incremented In Core.yaml