### PR TITLE
Fixed number of LEDs in the "RGB Light" entity  to 1

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  version:  "25.7.18.1"
+  version:  "25.7.18.2"
   device_description: ${name} made by Apollo Automation - version ${version}.
 
 esp32:
@@ -578,7 +578,8 @@ light:
     pin: GPIO3
     default_transition_length: 0s
     chipset: WS2812
-    num_leds: 3
+    num_leds: 1
+    rmt_symbols: 48
     rgb_order: grb
     effects:
       - pulse:


### PR DESCRIPTION

<!--
From Core.yaml. Should match date YY.MM.DD.# ( Usually # is 1 )
-->
Version: 25.7.18.2

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## What does this implement/fix?

1. Existing code has MSR-1 as having 3 LEDs in the strip (carryover from Air-1?).  I just corrected this to 1.

2. Proposing a default rmt_symbols value of 48. This is not strictly needed, but helps anyone adding a second LED strip from having to extend the "RGB Light" entity. 48 is the only real choice due to ESP32-C3's limit of 92 tx symbols, assignable in 48-symbol chunks (so it might as well be a default, as adding another RMT LED would require that one to be 48 as well).


## Types of changes
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:
<!--
  Put an x in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

  - [X] The code change has been tested and works locally
  - [ ] The code change has not yet been tested
  
If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

<!--
  Thank you for contributing <3
-->