### PR TITLE
[wifi_info] Add IP address text sensor

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -655,6 +655,7 @@ text_sensor:
     ip_address:
       name: "IP Address"
       id: wifi_ip
+      entity_category: "diagnostic"
   - platform: version
     name: "ESPHome Version"
     hide_timestamp: true


### PR DESCRIPTION
Version: 25.7.18.1

## What does this implement/fix?

Adds the device's current IP address as a diagnostic text sensor in Home Assistant.

This makes it easy to identify and connect to individual MSR-1 devices on the network without having to check the router.

## Types of changes

- [ ] Bugfix (fixed change that fixes an issue)
- [x] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:

  - [x] The code change has been tested and works locally
  - [ ] The code change has not yet been tested
  
If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Wi‑Fi IP Address sensor to display the device's current network IP for easier identification and connectivity checks.
  * Added an ESPHome Version sensor to surface the installed ESPHome release as a diagnostic.
  * Added an "Apollo Firmware Version" template sensor to expose firmware version details as a diagnostic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->