### PR TITLE
[api] Rename services to actions

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -649,6 +649,10 @@ text_sensor:
   - platform: ld2410
     version:
       name: "Radar Firmware Version"
+  - platform: wifi_info
+    ip_address:
+      name: "IP Address"
+      id: wifi_ip
 
 select:
   - platform: ld2410

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -653,6 +653,16 @@ text_sensor:
     ip_address:
       name: "IP Address"
       id: wifi_ip
+  - platform: version
+    name: "ESPHome Version"
+    hide_timestamp: true
+    entity_category: "diagnostic"
+  - platform: template
+    name: "Apollo Firmware Version"
+    id: apollo_firmware_version
+    lambda: |-
+      return {"${version}"};
+    entity_category: "diagnostic"
 
 select:
   - platform: ld2410

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -16,16 +16,16 @@ api:
     - delay: 1s
     - light.turn_off: rgb_light
     - lambda: 'id(cycleCounter) = 30;'
-  services:
-    - service: play_buzzer
+  actions:
+    - action: play_buzzer
       variables:
         song_str: string
       then:
         - rtttl.play:
             rtttl: !lambda 'return song_str;'
 
-    #Co2 Calibration Service
-    - service: calibrate_co2_value
+    #Co2 Calibration Action
+    - action: calibrate_co2_value
       variables:
         co2_ppm: float
       then:
@@ -34,7 +34,7 @@ api:
             id: scd40
 
     #Setting HLK Password
-    - service: set_ld2410_bluetooth_password
+    - action: set_ld2410_bluetooth_password
       variables:
         password: string
       then:


### PR DESCRIPTION
Version: 25.7.18.1

## What does this implement/fix?

ESPHome renamed the `services`/`service` keywords to `actions`/`action` in newer versions. This updates all three API entries in Core.yaml to use the current syntax:

- `play_buzzer`
- `calibrate_co2_value`
- `set_ld2410_bluetooth_password`

> **Breaking change:** Any Home Assistant automations or scripts that call these as services (e.g. `esphome.apollo_msr_1_play_buzzer`) must be updated to use the new action syntax after flashing this firmware.

## Types of changes

- [ ] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [x] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:

  - [x] The code change has been tested and works locally
  - [ ] The code change has not yet been tested
  
If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page