### PR TITLE
Add configurable update interval for LTR390 sensor

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -729,10 +729,16 @@ interval:
       - lambda: |-
           uint32_t current_time = millis() / 1000;  // Convert to seconds
           uint32_t last_update = id(ltr390_last_update);
-          uint32_t interval = (uint32_t)id(ltr390_update_interval).state;
+          float configured_interval = id(ltr390_update_interval).state;
+
+          // Fallback to 60s if not yet initialized or out of range
+          if (isnan(configured_interval) || configured_interval < 1.0f) {
+            configured_interval = 60.0f;
+          }
+          uint32_t interval = (uint32_t)configured_interval;
 
           // Immediate update on boot (when last_update is still 0)
-          if (last_update == 0 && current_time > 0) {
+          if (last_update == 0) {
             id(ltr_390).update();
             id(ltr390_last_update) = current_time;
             return;

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -730,12 +730,7 @@ interval:
           uint32_t current_time = millis() / 1000;  // Convert to seconds
           uint32_t last_update = id(ltr390_last_update);
           float configured_interval = id(ltr390_update_interval).state;
-
-          // Fallback to 60s if not yet initialized or out of range
-          if (isnan(configured_interval) || configured_interval < 1.0f) {
-            configured_interval = 60.0f;
-          }
-          uint32_t interval = (uint32_t)configured_interval;
+          uint32_t interval = (configured_interval >= 1.0f) ? (uint32_t)configured_interval : 60u;
 
           // Immediate update on boot (when last_update is still 0)
           if (last_update == 0) {

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -53,6 +53,10 @@ globals:
     restore_value: no
     type: uint32_t
     initial_value: '0'
+  - id: ltr390_last_update
+    restore_value: no
+    type: uint32_t
+    initial_value: '0'
 
 i2c:
   sda: GPIO1
@@ -146,6 +150,20 @@ number:
     optimistic: true
     update_interval: never
     step: 0.1
+    mode: box
+  - platform: template
+    name: LTR390 Update Interval
+    id: ltr390_update_interval
+    disabled_by_default: true
+    restore_value: true
+    initial_value: 60
+    min_value: 1
+    max_value: 300
+    entity_category: "CONFIG"
+    unit_of_measurement: "s"
+    optimistic: true
+    update_interval: never
+    step: 1
     mode: box
 # Setting start of zone 1 occupancy
   - platform: template
@@ -525,6 +543,7 @@ sensor:
   
   - platform: ltr390
     id: ltr_390
+    update_interval: never
     light:
       name: "LTR390 Light"
       id: ltr390light
@@ -704,3 +723,23 @@ interval:
             - light.turn_off:
                 id: rgb_light
             - lambda: 'id(cycleCounter) += 1;'
+
+  - interval: 1s
+    then:
+      - lambda: |-
+          uint32_t current_time = millis() / 1000;  // Convert to seconds
+          uint32_t last_update = id(ltr390_last_update);
+          uint32_t interval = (uint32_t)id(ltr390_update_interval).state;
+
+          // Immediate update on boot (when last_update is still 0)
+          if (last_update == 0 && current_time > 0) {
+            id(ltr_390).update();
+            id(ltr390_last_update) = current_time;
+            return;
+          }
+
+          // Check if enough time has passed
+          if (current_time - last_update >= interval) {
+            id(ltr_390).update();
+            id(ltr390_last_update) = current_time;
+          }


### PR DESCRIPTION
<!--
From Core.yaml. Should match date YY.MM.DD.# ( Usually # is 1 )
-->
Version: 26.3.2.1

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## What does this implement/fix?

Ports the configurable LTR390 update interval from MSR-2 (PR #56) to MSR-1.

- Adds `ltr390_last_update` global to track last poll timestamp
- Adds `LTR390 Update Interval` number entity (1–300s, default 60s, CONFIG category, persists across reboots)
- Sets `update_interval: never` on the LTR390 sensor to disable auto-polling
- Drives polling via a 1s interval lambda — triggers immediately on boot, then respects the configured interval

## Types of changes
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Bugfix (fixed change that fixes an issue)
- [x] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:
<!--
  Put an x in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

  - [ ] The code change has been tested and works locally
  - [x] The code change has not yet been tested
  
If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

<!--
  Thank you for contributing <3
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * LTR390 sensor now supports a configurable update interval (default 60s, range 1–300s) for flexible monitoring.
  * Sensor refreshes are now scheduled by that interval (no automatic continuous updates), with an immediate refresh on boot.
  * Scheduling checks occur at a 1-second cadence for timely, interval-driven updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->