### PR TITLE
Bump version to 26.3.2.1

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  version: "26.3.2.1"
+  version:  "26.3.2.1"
   device_description: ${name} made by Apollo Automation - version ${version}.
 
 esp32:
@@ -142,7 +142,7 @@ number:
     min_value: -70.0
     max_value: 70.0
     entity_category: "CONFIG"
-    unit_of_measurement: "°C"
+    unit_of_measurement: "Â°C"
     optimistic: true
     update_interval: never
     step: 0.1

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  version:  "25.7.18.1"
+  version: "26.3.2.1"
   device_description: ${name} made by Apollo Automation - version ${version}.
 
 esp32:
@@ -142,7 +142,7 @@ number:
     min_value: -70.0
     max_value: 70.0
     entity_category: "CONFIG"
-    unit_of_measurement: "Â°C"
+    unit_of_measurement: "°C"
     optimistic: true
     update_interval: never
     step: 0.1


### PR DESCRIPTION
Version: 26.3.2.1

Adds:
Version number update to Core.yaml
Fixes:

Breaks:

Checks:
- [ ] Documentation Updated
- [x] Build Number Incremented In YAML (YY.MM.DD.#)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ESPHome to version 26.3.2.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->