### PR TITLE
Fix: publish firmware version once on boot instead of polling

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -692,8 +692,7 @@ text_sensor:
   - platform: template
     name: "Apollo Firmware Version"
     id: apollo_firmware_version
-    lambda: |-
-      return {"${version}"};
+    update_interval: never
     entity_category: "diagnostic"
 
 select:

--- a/Integrations/ESPHome/MSR-1.yaml
+++ b/Integrations/ESPHome/MSR-1.yaml
@@ -6,11 +6,13 @@ esphome:
   on_boot:
   - priority: 900.0
     then:
+      - lambda: |-
+          id(radar_bluetooth).turn_off();
+  - priority: 500
+    then:
       - text_sensor.template.publish:
           id: apollo_firmware_version
           state: "${version}"
-      - lambda: |-
-          id(radar_bluetooth).turn_off();
 
   project:
     name: "ApolloAutomation.MSR-1"

--- a/Integrations/ESPHome/MSR-1.yaml
+++ b/Integrations/ESPHome/MSR-1.yaml
@@ -6,6 +6,9 @@ esphome:
   on_boot:
   - priority: 900.0
     then:
+      - text_sensor.template.publish:
+          id: apollo_firmware_version
+          state: "${version}"
       - lambda: |-
           id(radar_bluetooth).turn_off();
 

--- a/Integrations/ESPHome/MSR-1_BLE.yaml
+++ b/Integrations/ESPHome/MSR-1_BLE.yaml
@@ -8,6 +8,11 @@ esphome:
     then:
       - lambda: |-
           id(radar_bluetooth).turn_off();
+  - priority: 500
+    then:
+      - text_sensor.template.publish:
+          id: apollo_firmware_version
+          state: "${version}"
 
   project:
     name: "ApolloAutomation.MSR-1_BLE"

--- a/Integrations/ESPHome/MSR-1_Factory.yaml
+++ b/Integrations/ESPHome/MSR-1_Factory.yaml
@@ -8,6 +8,11 @@ esphome:
     then:
       - lambda: |-
           id(radar_bluetooth).turn_off();
+  - priority: 500
+    then:
+      - text_sensor.template.publish:
+          id: apollo_firmware_version
+          state: "${version}"
 
   project:
     name: "ApolloAutomation.MSR-1_Factory"


### PR DESCRIPTION
## Summary
- Replaced the 60s polling lambda with a single `text_sensor.template.publish` on boot
- Added `update_interval: never` back to the sensor definition since the value is a compile-time constant
- Consistent with the same fix applied across AIR-1, PLT-1, TEMP-1, BTN-1, and PUMP-1

Per ESPHome developer feedback: there's no need to poll a constant value every 60s — just publish it once at boot.