### PR TITLE
Release 26.3.2.1 - New sensors, ESPHome modernisation, and bug fixes

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -649,6 +649,10 @@ text_sensor:
   - platform: ld2410
     version:
       name: "Radar Firmware Version"
+  - platform: wifi_info
+    ip_address:
+      name: "IP Address"
+      id: wifi_ip
 
 select:
   - platform: ld2410

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  version: "26.3.2.1"
+  version:  "26.3.2.1"
   device_description: ${name} made by Apollo Automation - version ${version}.
 
 esp32:
@@ -142,7 +142,7 @@ number:
     min_value: -70.0
     max_value: 70.0
     entity_category: "CONFIG"
-    unit_of_measurement: "°C"
+    unit_of_measurement: "Â°C"
     optimistic: true
     update_interval: never
     step: 0.1

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  version:  "25.7.18.1"
+  version: "26.3.2.1"
   device_description: ${name} made by Apollo Automation - version ${version}.
 
 esp32:
@@ -142,7 +142,7 @@ number:
     min_value: -70.0
     max_value: 70.0
     entity_category: "CONFIG"
-    unit_of_measurement: "Â°C"
+    unit_of_measurement: "°C"
     optimistic: true
     update_interval: never
     step: 0.1

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -657,7 +657,6 @@ text_sensor:
     name: "ESPHome Version"
     hide_timestamp: true
     entity_category: "diagnostic"
-    entity_category: "diagnostic"
   - platform: template
     name: "Apollo Firmware Version"
     id: apollo_firmware_version

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -692,8 +692,7 @@ text_sensor:
   - platform: template
     name: "Apollo Firmware Version"
     id: apollo_firmware_version
-    lambda: |-
-      return {"${version}"};
+    update_interval: never
     entity_category: "diagnostic"
 
 select:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -729,10 +729,16 @@ interval:
       - lambda: |-
           uint32_t current_time = millis() / 1000;  // Convert to seconds
           uint32_t last_update = id(ltr390_last_update);
-          uint32_t interval = (uint32_t)id(ltr390_update_interval).state;
+          float configured_interval = id(ltr390_update_interval).state;
+
+          // Fallback to 60s if not yet initialized or out of range
+          if (isnan(configured_interval) || configured_interval < 1.0f) {
+            configured_interval = 60.0f;
+          }
+          uint32_t interval = (uint32_t)configured_interval;
 
           // Immediate update on boot (when last_update is still 0)
-          if (last_update == 0 && current_time > 0) {
+          if (last_update == 0) {
             id(ltr_390).update();
             id(ltr390_last_update) = current_time;
             return;

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -653,6 +653,16 @@ text_sensor:
     ip_address:
       name: "IP Address"
       id: wifi_ip
+  - platform: version
+    name: "ESPHome Version"
+    hide_timestamp: true
+    entity_category: "diagnostic"
+  - platform: template
+    name: "Apollo Firmware Version"
+    id: apollo_firmware_version
+    lambda: |-
+      return {"${version}"};
+    entity_category: "diagnostic"
 
 select:
   - platform: ld2410

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -663,6 +663,7 @@ text_sensor:
     id: apollo_firmware_version
     lambda: |-
       return {"${version}"};
+    update_interval: never
     entity_category: "diagnostic"
 
 select:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -3,13 +3,15 @@ substitutions:
   device_description: ${name} made by Apollo Automation - version ${version}.
 
 esp32:
-  board: esp32-c3-devkitm-1
+  variant: esp32c3
+  flash_size: 4MB
   framework:
     type: esp-idf
 captive_portal:
 
 web_server:
   port: 80
+  version: 3
 
 api:
   on_client_connected:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -730,12 +730,7 @@ interval:
           uint32_t current_time = millis() / 1000;  // Convert to seconds
           uint32_t last_update = id(ltr390_last_update);
           float configured_interval = id(ltr390_update_interval).state;
-
-          // Fallback to 60s if not yet initialized or out of range
-          if (isnan(configured_interval) || configured_interval < 1.0f) {
-            configured_interval = 60.0f;
-          }
-          uint32_t interval = (uint32_t)configured_interval;
+          uint32_t interval = (configured_interval >= 1.0f) ? (uint32_t)configured_interval : 60u;
 
           // Immediate update on boot (when last_update is still 0)
           if (last_update == 0) {

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -53,6 +53,10 @@ globals:
     restore_value: no
     type: uint32_t
     initial_value: '0'
+  - id: ltr390_last_update
+    restore_value: no
+    type: uint32_t
+    initial_value: '0'
 
 i2c:
   sda: GPIO1
@@ -146,6 +150,20 @@ number:
     optimistic: true
     update_interval: never
     step: 0.1
+    mode: box
+  - platform: template
+    name: LTR390 Update Interval
+    id: ltr390_update_interval
+    disabled_by_default: true
+    restore_value: true
+    initial_value: 60
+    min_value: 1
+    max_value: 300
+    entity_category: "CONFIG"
+    unit_of_measurement: "s"
+    optimistic: true
+    update_interval: never
+    step: 1
     mode: box
 # Setting start of zone 1 occupancy
   - platform: template
@@ -525,6 +543,7 @@ sensor:
   
   - platform: ltr390
     id: ltr_390
+    update_interval: never
     light:
       name: "LTR390 Light"
       id: ltr390light
@@ -704,3 +723,23 @@ interval:
             - light.turn_off:
                 id: rgb_light
             - lambda: 'id(cycleCounter) += 1;'
+
+  - interval: 1s
+    then:
+      - lambda: |-
+          uint32_t current_time = millis() / 1000;  // Convert to seconds
+          uint32_t last_update = id(ltr390_last_update);
+          uint32_t interval = (uint32_t)id(ltr390_update_interval).state;
+
+          // Immediate update on boot (when last_update is still 0)
+          if (last_update == 0 && current_time > 0) {
+            id(ltr_390).update();
+            id(ltr390_last_update) = current_time;
+            return;
+          }
+
+          // Check if enough time has passed
+          if (current_time - last_update >= interval) {
+            id(ltr_390).update();
+            id(ltr390_last_update) = current_time;
+          }

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -657,6 +657,7 @@ text_sensor:
     name: "ESPHome Version"
     hide_timestamp: true
     entity_category: "diagnostic"
+    entity_category: "diagnostic"
   - platform: template
     name: "Apollo Firmware Version"
     id: apollo_firmware_version

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -300,8 +300,18 @@ binary_sensor:
       } else {
         return false;
       }
+  - platform: template
+    name: "Radar Zone Occupancy"
+    id: "radar_zone_occupancy"
+    device_class: occupancy
+    icon: mdi:motion-sensor
+    lambda: |-
+      bool zone1 = id(radar_zone_1_occupancy).state;
+      bool zone2 = id(radar_zone_2_occupancy).state;
+      bool zone3 = id(radar_zone_3_occupancy).state;
+      return zone1 || zone2 || zone3;
   - platform: gpio
-    pin: 
+    pin:
       number: GPIO9
       inverted: true
       ignore_strapping_warning: true

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -655,6 +655,7 @@ text_sensor:
     ip_address:
       name: "IP Address"
       id: wifi_ip
+      entity_category: "diagnostic"
   - platform: version
     name: "ESPHome Version"
     hide_timestamp: true

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -16,16 +16,16 @@ api:
     - delay: 1s
     - light.turn_off: rgb_light
     - lambda: 'id(cycleCounter) = 30;'
-  services:
-    - service: play_buzzer
+  actions:
+    - action: play_buzzer
       variables:
         song_str: string
       then:
         - rtttl.play:
             rtttl: !lambda 'return song_str;'
 
-    #Co2 Calibration Service
-    - service: calibrate_co2_value
+    #Co2 Calibration Action
+    - action: calibrate_co2_value
       variables:
         co2_ppm: float
       then:
@@ -34,7 +34,7 @@ api:
             id: scd40
 
     #Setting HLK Password
-    - service: set_ld2410_bluetooth_password
+    - action: set_ld2410_bluetooth_password
       variables:
         password: string
       then:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -694,7 +694,6 @@ text_sensor:
     id: apollo_firmware_version
     lambda: |-
       return {"${version}"};
-    update_interval: never
     entity_category: "diagnostic"
 
 select:

--- a/Integrations/ESPHome/MSR-1.yaml
+++ b/Integrations/ESPHome/MSR-1.yaml
@@ -6,11 +6,13 @@ esphome:
   on_boot:
   - priority: 900.0
     then:
+      - lambda: |-
+          id(radar_bluetooth).turn_off();
+  - priority: 500
+    then:
       - text_sensor.template.publish:
           id: apollo_firmware_version
           state: "${version}"
-      - lambda: |-
-          id(radar_bluetooth).turn_off();
 
   project:
     name: "ApolloAutomation.MSR-1"

--- a/Integrations/ESPHome/MSR-1.yaml
+++ b/Integrations/ESPHome/MSR-1.yaml
@@ -19,6 +19,8 @@ dashboard_import:
   package_import_url: github://ApolloAutomation/MSR-1/Integrations/ESPHome/MSR-1.yaml
   import_full_config: false
 
+logger:
+
 ota:
   - platform: esphome
     password: "apolloautomation"

--- a/Integrations/ESPHome/MSR-1.yaml
+++ b/Integrations/ESPHome/MSR-1.yaml
@@ -6,6 +6,9 @@ esphome:
   on_boot:
   - priority: 900.0
     then:
+      - text_sensor.template.publish:
+          id: apollo_firmware_version
+          state: "${version}"
       - lambda: |-
           id(radar_bluetooth).turn_off();
 

--- a/Integrations/ESPHome/MSR-1.yaml
+++ b/Integrations/ESPHome/MSR-1.yaml
@@ -3,9 +3,6 @@ esphome:
   friendly_name: Apollo Multisensor Mk1 (MSR-1)
   comment: Apollo Multisensor Mk1 (MSR-1)
   name_add_mac_suffix: true
-  platformio_options:
-    board_build.flash_mode: dio
-
   on_boot:
   - priority: 900.0
     then:
@@ -35,6 +32,7 @@ captive_portal:
 
 web_server:
   port: 80
+  version: 3
 
 packages:
   core: !include Core.yaml

--- a/Integrations/ESPHome/MSR-1_BLE.yaml
+++ b/Integrations/ESPHome/MSR-1_BLE.yaml
@@ -8,6 +8,11 @@ esphome:
     then:
       - lambda: |-
           id(radar_bluetooth).turn_off();
+  - priority: 500
+    then:
+      - text_sensor.template.publish:
+          id: apollo_firmware_version
+          state: "${version}"
 
   project:
     name: "ApolloAutomation.MSR-1_BLE"

--- a/Integrations/ESPHome/MSR-1_BLE.yaml
+++ b/Integrations/ESPHome/MSR-1_BLE.yaml
@@ -19,6 +19,8 @@ dashboard_import:
   package_import_url: github://ApolloAutomation/MSR-1/Integrations/ESPHome/MSR-1_BLE.yaml
   import_full_config: false
 
+logger:
+
 ota:
   - platform: esphome
     password: "apolloautomation"

--- a/Integrations/ESPHome/MSR-1_BLE.yaml
+++ b/Integrations/ESPHome/MSR-1_BLE.yaml
@@ -26,7 +26,6 @@ dashboard_import:
   package_import_url: github://ApolloAutomation/MSR-1/Integrations/ESPHome/MSR-1_BLE.yaml
   import_full_config: false
 
-logger:
 
 ota:
   - platform: esphome

--- a/Integrations/ESPHome/MSR-1_BLE.yaml
+++ b/Integrations/ESPHome/MSR-1_BLE.yaml
@@ -3,9 +3,6 @@ esphome:
   friendly_name: Apollo Multisensor Mk1 (MSR-1)
   comment: Apollo Multisensor Mk1 (MSR-1)
   name_add_mac_suffix: true
-  platformio_options:
-    board_build.flash_mode: dio
-
   on_boot:
   - priority: 900.0
     then:

--- a/Integrations/ESPHome/MSR-1_Factory.yaml
+++ b/Integrations/ESPHome/MSR-1_Factory.yaml
@@ -8,6 +8,11 @@ esphome:
     then:
       - lambda: |-
           id(radar_bluetooth).turn_off();
+  - priority: 500
+    then:
+      - text_sensor.template.publish:
+          id: apollo_firmware_version
+          state: "${version}"
 
   project:
     name: "ApolloAutomation.MSR-1_Factory"

--- a/Integrations/ESPHome/MSR-1_Factory.yaml
+++ b/Integrations/ESPHome/MSR-1_Factory.yaml
@@ -3,9 +3,6 @@ esphome:
   friendly_name: Apollo Multisensor Mk1 (MSR-1)
   comment: Apollo Multisensor Mk1 (MSR-1)
   name_add_mac_suffix: true
-  platformio_options:
-    board_build.flash_mode: dio
-
   on_boot:
   - priority: 900.0
     then:
@@ -28,11 +25,6 @@ esp32_improv:
   authorizer: none
 
 wifi:
-  on_connect:
-    - delay: 5s  
-    - ble.disable:
-  on_disconnect:
-    - ble.enable:
   ap:
     ssid: "Apollo MSR1 Hotspot"
 


### PR DESCRIPTION
<!--
From Core.yaml. Should match date YY.MM.DD.# ( Usually # is 1 )
-->
Version: 26.3.2.1

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## What does this implement/fix?

Merges beta into main for the 26.3.2.1 release. Changes include:

- **ESPHome modernisation** — `esp32c3` board variant + `flash_size: 4MB`, web server v3, remove legacy platformio options and BLE on_connect/on_disconnect wifi hooks from Factory YAML *(breaking: board spec change)*
- **API services → actions rename** — `play_buzzer`, `calibrate_co2_value`, `set_ld2410_bluetooth_password` renamed from `services` to `actions` *(breaking: existing HA automations calling these services will need updating)*
- **General Radar Zone Occupancy sensor** — consolidated binary sensor aggregating zones 1, 2, and 3 for simpler automations
- **Configurable LTR390 update interval** — adjustable 1–300s via web interface, persisted across reboots
- **IP address text sensor** — via `wifi_info` platform
- **ESPHome version + Apollo firmware version text sensors**
- **Logger added** to MSR-1.yaml and MSR-1_BLE.yaml to match Factory variant
- **Bug fixes** — Apollo firmware version showing "unknown", LTR390 interval NaN handling, UTF-8 special character restoration

## Types of changes
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Bugfix (fixed change that fixes an issue)
- [x] New feature (thanks!)
- [x] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:
<!--
  Put an x in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

  - [x] The code change has been tested and works locally
  - [ ] The code change has not yet been tested
  
If user-visible functionality or configuration variables are added/modified:
  - [x] Added/updated documentation for the web page

<!--
  Thank you for contributing <3
-->