### PR TITLE
Merge main into beta to resolve conflicts

### DIFF
--- a/.github/workflows/autoassign.yml
+++ b/.github/workflows/autoassign.yml
@@ -15,5 +15,5 @@ jobs:
       uses: pozil/auto-assign-issue@v1
       with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          assignees: TrevorSchirmer
+          assignees: bharvey88
           numOfAssignee: 1

--- a/.github/workflows/autoassign.yml
+++ b/.github/workflows/autoassign.yml
@@ -12,7 +12,7 @@ jobs:
       pull-requests: write
     steps:
     - name: 'Auto-assign issue'
-      uses: pozil/auto-assign-issue@v1
+      uses: pozil/auto-assign-issue@v2
       with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           assignees: bharvey88

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       device-name: msr-2
       yaml-files: |
         Integrations/ESPHome/MSR-1_Factory.yaml
-      firmware-names: "_Factory:firmware"
+      firmware-names: "1_Factory:firmware"
       core-yaml-path: Integrations/ESPHome/Core.yaml
       esphome-version: stable
       # Bypass check if manually triggered with bypass option

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           - dev
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6.0.2
       - name: Build ESPHome firmware to verify configuration
         uses: esphome/build-action@v7
         with:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  version:  "25.7.29.1"
+  version:  "25.8.6.1"
   device_description: ${name} made by Apollo Automation - version ${version}.
 
 esp32:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  version:  "25.7.18.2"
+  version:  "25.7.29.1"
   device_description: ${name} made by Apollo Automation - version ${version}.
 
 esp32:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  version:  "25.7.18.1"
+  version:  "25.7.18.2"
   device_description: ${name} made by Apollo Automation - version ${version}.
 
 esp32:
@@ -578,7 +578,8 @@ light:
     pin: GPIO3
     default_transition_length: 0s
     chipset: WS2812
-    num_leds: 3
+    num_leds: 1
+    rmt_symbols: 48
     rgb_order: grb
     effects:
       - pulse:

--- a/Integrations/ESPHome/MSR-1_BLE.yaml
+++ b/Integrations/ESPHome/MSR-1_BLE.yaml
@@ -18,6 +18,8 @@ esphome:
 
   min_version: 2025.2.0
 
+logger:
+
 dashboard_import:
   package_import_url: github://ApolloAutomation/MSR-1/Integrations/ESPHome/MSR-1_BLE.yaml
   import_full_config: false

--- a/Integrations/ESPHome/MSR-1_BLE.yaml
+++ b/Integrations/ESPHome/MSR-1_BLE.yaml
@@ -26,7 +26,6 @@ dashboard_import:
   package_import_url: github://ApolloAutomation/MSR-1/Integrations/ESPHome/MSR-1_BLE.yaml
   import_full_config: false
 
-logger:
 
 ota:
   - platform: esphome


### PR DESCRIPTION
## Summary
- Merges main into beta to resolve merge conflicts on PR #78
- Keeps all beta changes (ESPHome modernisation, new sensors, actions API)
- Preserves main's `num_leds: 1` fix and `rmt_symbols: 48`

## Files resolved
- `Integrations/ESPHome/Core.yaml` — kept beta + patched LED count from main
- `Integrations/ESPHome/MSR-1_BLE.yaml` — kept beta (already includes logger from main)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD automation: workflow actions and build input selection adjusted to streamline builds and repository checkout.
  * Updated automation assignment settings.
  * Optimized device integration: LED configuration reduced and timing adjusted for improved behavior, and logging configuration moved earlier for more consistent startup diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->