### PR TITLE
chore(esphome): parameterize OTA password (preserve current default)

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,6 +1,10 @@
 substitutions:
   version:  "26.3.2.1"
   device_description: ${name} made by Apollo Automation - version ${version}.
+  # Default OTA password. Override in your device YAML by re-declaring
+  # `substitutions: { ota_password: !secret <name>_ota_password }` so each
+  # device on your network uses a unique secret instead of the shared default.
+  ota_password: "apolloautomation"
 
 esp32:
   variant: esp32c3

--- a/Integrations/ESPHome/MSR-1.yaml
+++ b/Integrations/ESPHome/MSR-1.yaml
@@ -28,7 +28,7 @@ logger:
 
 ota:
   - platform: esphome
-    password: "apolloautomation"
+    password: ${ota_password}
 
 wifi:
   power_save_mode: none

--- a/Integrations/ESPHome/MSR-1_BLE.yaml
+++ b/Integrations/ESPHome/MSR-1_BLE.yaml
@@ -29,7 +29,7 @@ dashboard_import:
 
 ota:
   - platform: esphome
-    password: "apolloautomation"
+    password: ${ota_password}
 
 wifi:
   ap:


### PR DESCRIPTION
<!--
From Core.yaml. Should match date YY.MM.DD.# ( Usually # is 1 )
-->
Version: 26.3.2.1

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## What does this implement/fix?

Promotes the hardcoded `password: "apolloautomation"` literal in `MSR-1.yaml` and `MSR-1_BLE.yaml` to a `${ota_password}` substitution defined in `Core.yaml`, with the existing literal kept as the default. **No behavior change** for anyone who doesn't override.

### Why

Every Apollo MSR-1 currently boots with the same fleet-wide OTA password. Consumers who include this YAML via ESPHome `packages:` cannot override the password from their device file because:

- ESPHome packages **extend** list-valued keys, so adding a second `ota: - platform: esphome` block in the consumer file produces a duplicate-platform validation error.
- `ota: !remove` removes the package's contribution, but YAML disallows two top-level `ota:` keys, so the consumer can't redeclare in the same document.
- The current upstream YAML doesn't expose the password as a substitution.

The only existing workaround is to fork or vendor a local copy of this file — neither of which keeps the upstream `package_import_url` flow working.

The newer Apollo product configs (MSR-2, MTR-1, PWR-1, TEMP-1, PLT-1, BTN-1, RLY-1, H-1, H-2, PUMP-1) all have `ota:` blocks but no hardcoded password literal — only MSR-1 and AIR-1 still ship with one. A sibling PR has been opened against AIR-1 with the same change.

### What changes

```yaml
# Core.yaml
substitutions:
  version:  "26.3.2.1"
  device_description: ${name} made by Apollo Automation - version ${version}.
  # Default OTA password. Override in your device YAML by re-declaring
  # `substitutions: { ota_password: !secret <name>_ota_password }` so each
  # device on your network uses a unique secret instead of the shared default.
  ota_password: "apolloautomation"
```

```yaml
# MSR-1.yaml + MSR-1_BLE.yaml
ota:
  - platform: esphome
    password: ${ota_password}
```

### Override pattern (consumer device YAML)

```yaml
substitutions:
  ota_password: !secret kitchen_msr_1_ota_password

packages:
  ApolloAutomation.MSR-1: github://ApolloAutomation/MSR-1/Integrations/ESPHome/MSR-1.yaml
```

### Backwards compat

100% — devices that don't set `ota_password` get the same `"apolloautomation"` literal as before. Existing consumers, CI builds, and OTA flow unchanged.

## Types of changes
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [x] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:
<!--
  Put an x in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

  - [ ] The code change has been tested and works locally
  - [x] The code change has not yet been tested
  
If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

<!--
  Thank you for contributing <3
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated OTA password configuration to use variable substitution across ESPHome device files
  * Added default OTA password setting with per-device override capability via substitution pattern

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ApolloAutomation/MSR-1/pull/81?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->