### PR TITLE
Add managed firmware update system

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,6 +2,7 @@ name-template: 'Release v$NEXT_PATCH_VERSION'
 tag-template: "$RESOLVED_VERSION"
 change-template: "- #$NUMBER $TITLE @$AUTHOR"
 sort-direction: ascending
+category-template: '**$TITLE**'
 
 categories:
   - title: "🚨 Breaking changes"
@@ -25,11 +26,9 @@ include-labels:
 
 no-changes-template: '- No changes'
 
+# The shared build workflow appends a Full Changelog compare link to the
+# release body (release-drafter cannot render 4-part version tags).
 template: |
-  ## What's Changed
+  **What's Changed**
 
   $CHANGES
-
-  **Full Changelog**: https://github.com/ApolloAutomation/MSR-1/compare/$PREVIOUS_TAG...$RESOLVED_VERSION.1
-
-   Be sure to 🌟 this repository for updates!

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,8 @@ jobs:
       device-name: msr-2
       yaml-files: |
         Integrations/ESPHome/MSR-1_Factory.yaml
-      firmware-names: "1_Factory:firmware"
+        Integrations/ESPHome/MSR-1_BLE.yaml
+      firmware-names: "1_Factory:firmware,1_BLE:firmware-ble"
       core-yaml-path: Integrations/ESPHome/Core.yaml
       esphome-version: stable
       # Bypass check if manually triggered with bypass option

--- a/Integrations/ESPHome/MSR-1.yaml
+++ b/Integrations/ESPHome/MSR-1.yaml
@@ -33,6 +33,8 @@ ota:
     id: ota_managed
 
 wifi:
+  on_connect:
+    - component.update: update_http_request
   power_save_mode: none
   ap:
     ssid: "Apollo MSR1 Hotspot"

--- a/Integrations/ESPHome/MSR-1.yaml
+++ b/Integrations/ESPHome/MSR-1.yaml
@@ -29,6 +29,8 @@ logger:
 ota:
   - platform: esphome
     password: ${ota_password}
+  - platform: http_request
+    id: ota_managed
 
 wifi:
   power_save_mode: none
@@ -40,6 +42,17 @@ captive_portal:
 web_server:
   port: 80
   version: 3
+
+http_request:
+  verify_ssl: true
+
+safe_mode:
+
+update:
+  - platform: http_request
+    id: update_http_request
+    name: Firmware Update
+    source: https://apolloautomation.github.io/MSR-1/firmware/manifest.json
 
 packages:
   core: !include Core.yaml

--- a/Integrations/ESPHome/MSR-1.yaml
+++ b/Integrations/ESPHome/MSR-1.yaml
@@ -18,7 +18,7 @@ esphome:
     name: "ApolloAutomation.MSR-1"
     version: "${version}"
 
-  min_version: 2025.2.0
+  min_version: 2025.11.0
   
 dashboard_import:
   package_import_url: github://ApolloAutomation/MSR-1/Integrations/ESPHome/MSR-1.yaml

--- a/Integrations/ESPHome/MSR-1_BLE.yaml
+++ b/Integrations/ESPHome/MSR-1_BLE.yaml
@@ -34,6 +34,8 @@ ota:
     id: ota_managed
 
 wifi:
+  on_connect:
+    - component.update: update_http_request
   ap:
     ssid: "Apollo MSR1 Hotspot"
 

--- a/Integrations/ESPHome/MSR-1_BLE.yaml
+++ b/Integrations/ESPHome/MSR-1_BLE.yaml
@@ -30,6 +30,8 @@ dashboard_import:
 ota:
   - platform: esphome
     password: ${ota_password}
+  - platform: http_request
+    id: ota_managed
 
 wifi:
   ap:
@@ -37,6 +39,17 @@ wifi:
 
 bluetooth_proxy:
   active: true
+
+http_request:
+  verify_ssl: true
+
+safe_mode:
+
+update:
+  - platform: http_request
+    id: update_http_request
+    name: Firmware Update
+    source: https://apolloautomation.github.io/MSR-1/firmware-ble/manifest.json
 
 packages:
   core: !include Core.yaml

--- a/Integrations/ESPHome/MSR-1_BLE.yaml
+++ b/Integrations/ESPHome/MSR-1_BLE.yaml
@@ -18,7 +18,7 @@ esphome:
     name: "ApolloAutomation.MSR-1_BLE"
     version: "${version}"
 
-  min_version: 2025.2.0
+  min_version: 2025.11.0
 
 logger:
 

--- a/Integrations/ESPHome/MSR-1_Factory.yaml
+++ b/Integrations/ESPHome/MSR-1_Factory.yaml
@@ -38,6 +38,19 @@ logger:
 ota:
   - platform: esphome
     id: ota_esphome
+  - platform: http_request
+    id: ota_managed
+
+http_request:
+  verify_ssl: true
+
+safe_mode:
+
+update:
+  - platform: http_request
+    id: update_http_request
+    name: Firmware Update
+    source: https://apolloautomation.github.io/MSR-1/firmware/manifest.json
 
 packages:
   core: !include Core.yaml

--- a/Integrations/ESPHome/MSR-1_Factory.yaml
+++ b/Integrations/ESPHome/MSR-1_Factory.yaml
@@ -18,7 +18,7 @@ esphome:
     name: "ApolloAutomation.MSR-1_Factory"
     version: "${version}"
 
-  min_version: 2025.2.0
+  min_version: 2025.11.0
 
 dashboard_import:
   package_import_url: github://ApolloAutomation/MSR-1/Integrations/ESPHome/MSR-1.yaml

--- a/Integrations/ESPHome/MSR-1_Factory.yaml
+++ b/Integrations/ESPHome/MSR-1_Factory.yaml
@@ -30,6 +30,8 @@ esp32_improv:
   authorizer: none
 
 wifi:
+  on_connect:
+    - component.update: update_http_request
   ap:
     ssid: "Apollo MSR1 Hotspot"
 


### PR DESCRIPTION
Ports the managed OTA update system from R_PRO-1 to all MSR-1 variants, so devices can self-update from the GitHub Pages manifests directly in Home Assistant. MSR-1 already publishes `firmware/manifest.json` to Pages; this adds the device-side half.

## Changes

- `update: http_request` component (Firmware Update entity in HA) + `ota: http_request` platform on all three variants
- `safe_mode` for boot-loop recovery after a bad flash
- `http_request` with `verify_ssl: true` (esp-idf TLS, same as R_PRO-1)
- BLE variant is now built and published by CI to its own `firmware-ble/` manifest, and `MSR-1_BLE.yaml` updates from it — without this, a BLE device taking an update would be silently converted to the factory (non-BLE) firmware and lose Bluetooth proxy
- Manifest check triggered on `wifi.on_connect`: the update component's first 6-hour poll fires before the network is up and skips silently, leaving the entity stale for ~6h after every boot (R_PRO-1 has this today). The trigger makes the entity accurate within seconds of boot.
- `min_version` raised to 2025.11.0 to match the floor R_PRO-1 set when this system landed there

## Testing

The identical port was tested end to end on a physical MTR-1 (factory and BLE manifest paths): flash → update offered in HA with release notes → OTA install from Pages → reboot on new version → Bluetooth proxy intact on the BLE variant. All three MSR-1 variants compile-verified on ESPHome 2026.1.3.

Note for support: devices need outbound HTTPS (443) to `apolloautomation.github.io` — isolated IoT VLANs that block egress will show "up to date" forever with `ESP_ERR_HTTP_CONNECT` in debug logs.