### PR TITLE
Add Bluetooth Proxy firmware switching from HA

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,12 +1,13 @@
 substitutions:
-  version:  "26.7.8.4"
+  version:  "26.7.8.5"
   device_description: ${name} made by Apollo Automation - version ${version}.
   # Default OTA password. Override in your device YAML by re-declaring
   # `substitutions: { ota_password: !secret <name>_ota_password }` so each
   # device on your network uses a unique secret instead of the shared default.
   ota_password: "apolloautomation"
-  # Firmware variant identity: overridden to "true" by MSR-1_BLE.yaml so
-  # each image tracks its own OTA manifests.
+  # Firmware variant identity: overridden to "true" by MSR-1_BLE.yaml. Seeds
+  # the Bluetooth Proxy select on boot so it self-corrects to what is
+  # actually running after a failed or abandoned switch.
   ble_firmware: "false"
   # Default update channel on first boot (no stored user choice yet, i.e. a
   # fresh flash). The beta-channel builds override this to "Beta" (see
@@ -17,6 +18,22 @@ substitutions:
   # Beta = rolling "beta" pre-release assets (beta branch builds).
   stable_manifest_base: "https://apolloautomation.github.io/MSR-1"
   beta_manifest_base: "https://github.com/ApolloAutomation/MSR-1/releases/download/beta-fw"
+
+esphome:
+  # List form so package merging concatenates with each variant's own on_boot
+  # entries (mapping form would be replaced by the variant's block instead).
+  on_boot:
+    - priority: -100
+      then:
+        # The Bluetooth Proxy select mirrors the firmware actually running, so
+        # a failed or abandoned switch snaps back to the truth on reboot.
+        - lambda: |-
+            if (std::string("${ble_firmware}") == "true") {
+              id(firmware_ble).publish_state("Enabled");
+            } else {
+              id(firmware_ble).publish_state("Disabled");
+            }
+        - script.execute: apply_ota_source
 
 esp32:
   variant: esp32c3
@@ -768,14 +785,29 @@ select:
       then:
         - script.execute: apply_ota_source
 
+  - platform: template
+    name: "Bluetooth Proxy"
+    id: firmware_ble
+    icon: mdi:bluetooth
+    entity_category: "config"
+    optimistic: true
+    restore_value: true
+    options:
+      - "Disabled"
+      - "Enabled"
+    initial_option: "Disabled"
+    on_value:
+      then:
+        - script.execute: apply_ota_source
+
 script:
   - id: apply_ota_source
-    # Sets the OTA manifest URL from the Firmware Channel select
-    # (Stable/Beta) for the firmware variant this image was built as.
+    # Sets the OTA manifest URL from the two selectors: Bluetooth Proxy
+    # (Disabled/Enabled) x Firmware Channel (Stable/Beta).
     # Stable = GitHub Pages, Beta = rolling "beta" release assets.
     then:
       - lambda: |-
-          const bool ble  = std::string("${ble_firmware}") == "true";
+          const bool ble  = id(firmware_ble).current_option() == "Enabled";
           const bool beta = id(firmware_channel).current_option() == "Beta";
           std::string url;
           if (beta) {


### PR DESCRIPTION
Version: 26.7.8.5

## What does this implement/fix?

The second half of the ApolloAutomation/AIR-1#107 split: **Bluetooth Proxy switching from HA**. Users can turn an MSR-1 into a Bluetooth proxy (and back) with a dropdown instead of a USB reflash or YAML editing.

- **Bluetooth Proxy** select (Disabled/Enabled) joins the Firmware Channel select in composing the OTA manifest URL via `apply_ota_source` (one-line change: the variant now comes from the select instead of the build-time substitution).
- **Boot truth-sync**: on boot each image publishes what it actually is into the select (`ble_firmware` substitution), so a failed or abandoned switch snaps back to reality on reboot.
- Same-version variant switches install via the existing **Firmware Update** force button (merged in #89), which already disables BLE during the download to free heap for TLS.

**No workflow changes** - beta and Pages already publish both variants and their manifests, so this is one file, Core.yaml only.

To test on hardware: flash the standard image from the rolling `beta` release, flip Bluetooth Proxy to Enabled, press Firmware Update - the device should reinstall as the BLE image and the select should still read Enabled after reboot. Flip back to test the reverse path. Abandon a switch (toggle without pressing the button, then reboot) to see the truth-sync snap the select back.

Both selects config-validated on all three variants (ESPHome 2026.6.4). Not yet tested on hardware.

## Types of changes

- [ ] Bugfix (fixed change that fixes an issue)
- [x] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:

  - [ ] The code change has been tested and works locally
  - [x] The code change has not yet been tested

If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new **Bluetooth Proxy** toggle in the device interface, allowing Bluetooth proxy mode to be switched on or off.
  * Devices now apply the selected OTA source automatically at startup.

* **Bug Fixes**
  * Improved consistency so the Bluetooth proxy setting is correctly restored and applied after reboot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->