### PR TITLE
Rename rolling beta release tag to beta-fw (branch/tag collision)

### DIFF
--- a/.github/workflows/build-beta.yml
+++ b/.github/workflows/build-beta.yml
@@ -1,7 +1,7 @@
 name: Build and Publish Beta
 
 # Builds MSR-1 firmware from the beta branch and publishes it as assets on a
-# rolling "beta" pre-release. The on-device "Firmware Channel" select points
+# rolling "beta-fw" pre-release. The on-device "Firmware Channel" select points
 # OTA updates at these assets. Stable firmware is built/published separately
 # by build.yml (push to main -> GitHub Pages).
 
@@ -63,12 +63,12 @@ jobs:
           path: fw
           pattern: firmware*
 
-      - name: Ensure rolling 'beta' pre-release exists
+      - name: Ensure rolling 'beta-fw' pre-release exists
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release view beta -R "${{ github.repository }}" >/dev/null 2>&1 \
-            || gh release create beta -R "${{ github.repository }}" \
+          gh release view beta-fw -R "${{ github.repository }}" >/dev/null 2>&1 \
+            || gh release create beta-fw -R "${{ github.repository }}" \
                  --prerelease --title "Beta (rolling)" \
                  --notes "Latest MSR-1 beta firmware. Auto-updated on every push to the beta branch."
 
@@ -76,7 +76,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          BASE="https://github.com/${{ github.repository }}/releases/download/beta"
+          BASE="https://github.com/${{ github.repository }}/releases/download/beta-fw"
           declare -A DIRS=( [standard]=firmware-standard [ble]=firmware-ble-beta )
           for v in standard ble; do
             src="fw/${DIRS[$v]}"
@@ -98,8 +98,8 @@ jobs:
               | .builds[0].parts |= map(.path = ($base + "/" + $pfx + (.path | sub(".*/"; ""))))
             ' "$man" > "manifest-$v.json"
             cat "manifest-$v.json"
-            gh release upload beta "manifest-$v.json" -R "${{ github.repository }}" --clobber
+            gh release upload beta-fw "manifest-$v.json" -R "${{ github.repository }}" --clobber
             find "$src" -name '*.bin' -print -exec \
-              gh release upload beta {} -R "${{ github.repository }}" --clobber \;
+              gh release upload beta-fw {} -R "${{ github.repository }}" --clobber \;
           done
           echo "Beta assets published."

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  version:  "26.7.7.1"
+  version:  "26.7.8.2"
   device_description: ${name} made by Apollo Automation - version ${version}.
   # Default OTA password. Override in your device YAML by re-declaring
   # `substitutions: { ota_password: !secret <name>_ota_password }` so each
@@ -11,7 +11,7 @@ substitutions:
   # Manifest URL bases. Stable = GitHub Pages (main branch builds).
   # Beta = rolling "beta" pre-release assets (beta branch builds).
   stable_manifest_base: "https://apolloautomation.github.io/MSR-1"
-  beta_manifest_base: "https://github.com/ApolloAutomation/MSR-1/releases/download/beta"
+  beta_manifest_base: "https://github.com/ApolloAutomation/MSR-1/releases/download/beta-fw"
 
 esp32:
   variant: esp32c3


### PR DESCRIPTION
Version: 26.7.8.2

## What does this implement/fix?

The rolling pre-release created a tag named `beta`, colliding with the `beta` branch. git resolves a bare fetch refspec to `refs/tags/` before `refs/heads/`, so ESPHome remote packages pinned to `ref: beta` silently fetch the tag - which was frozen at creation time and never moves - instead of the branch tip. Users following beta as a package get stale YAML no matter how often they clean caches.

Reproduced end-to-end with an isolated cache: ESPHome's `git.py` runs `git fetch --depth=1 -- origin beta` then `git reset --hard FETCH_HEAD`, and `.git/FETCH_HEAD` shows `tag 'beta'` being fetched. On MSR-1 the tag pointed at main's then-HEAD (`e24fc3f`, 26.3.2.1) while the branch tip was `73fd740` (26.7.7.1 with the Firmware Channel select).

Fix: rename the release tag to `beta-fw` and update the beta manifest URLs to match. After this merges and the renamed release is populated by the next beta build, the old `beta` release + tag should be deleted. Until then, affected users can pin `ref: refs/heads/beta`.

Note: 26.7.8.1 is reserved by open PR #90, which will need a trivial rebase over this. Both variants config-validated on ESPHome 2026.6.4.

## Types of changes

- [x] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:

  - [ ] The code change has been tested and works locally
  - [x] The code change has not yet been tested

If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Beta firmware downloads and update manifests now point to the new rolling release channel, improving how beta builds are delivered.
* **Bug Fixes**
  * Updated beta update paths so the correct firmware assets are used during OTA and manifest retrieval.
* **Chores**
  * Bumped the bundled ESPHome integration version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->