### PR TITLE
Default the Firmware Channel select to Beta on beta-channel builds

### DIFF
--- a/.github/workflows/build-beta.yml
+++ b/.github/workflows/build-beta.yml
@@ -41,8 +41,8 @@ jobs:
         include:
           # Beta serves OTA updates only, so it builds the end-user image
           # (MSR-1.yaml), not the first-flash Factory image.
-          - { yaml: Integrations/ESPHome/MSR-1.yaml,     name: firmware-standard }
-          - { yaml: Integrations/ESPHome/MSR-1_BLE.yaml, name: firmware-ble-beta }
+          - { yaml: Integrations/ESPHome/beta-channel/MSR-1.yaml,     name: firmware-standard }
+          - { yaml: Integrations/ESPHome/beta-channel/MSR-1_BLE.yaml, name: firmware-ble-beta }
     uses: esphome/workflows/.github/workflows/build.yml@025a1e6255610c498ed590403b7e510b69e474df # 2026.4.1
     with:
       files: ${{ matrix.yaml }}

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  version:  "26.7.8.2"
+  version:  "26.7.8.4"
   device_description: ${name} made by Apollo Automation - version ${version}.
   # Default OTA password. Override in your device YAML by re-declaring
   # `substitutions: { ota_password: !secret <name>_ota_password }` so each
@@ -8,6 +8,11 @@ substitutions:
   # Firmware variant identity: overridden to "true" by MSR-1_BLE.yaml so
   # each image tracks its own OTA manifests.
   ble_firmware: "false"
+  # Default update channel on first boot (no stored user choice yet, i.e. a
+  # fresh flash). The beta-channel builds override this to "Beta" (see
+  # Integrations/ESPHome/beta-channel/) so firmware obtained from the beta
+  # channel keeps tracking it instead of offering a stable "downgrade".
+  firmware_channel_default: "Stable"
   # Manifest URL bases. Stable = GitHub Pages (main branch builds).
   # Beta = rolling "beta" pre-release assets (beta branch builds).
   stable_manifest_base: "https://apolloautomation.github.io/MSR-1"
@@ -758,7 +763,7 @@ select:
     options:
       - "Stable"
       - "Beta"
-    initial_option: "Stable"
+    initial_option: "${firmware_channel_default}"
     on_value:
       then:
         - script.execute: apply_ota_source

--- a/Integrations/ESPHome/beta-channel/MSR-1.yaml
+++ b/Integrations/ESPHome/beta-channel/MSR-1.yaml
@@ -1,0 +1,9 @@
+# Beta-channel build of MSR-1.yaml: the identical image except the Firmware
+# Channel select defaults to "Beta" on first boot, so firmware obtained from
+# the beta channel keeps tracking it. Built by build-beta.yml only; the
+# stable (GitHub Pages) builds use MSR-1.yaml directly.
+substitutions:
+  firmware_channel_default: "Beta"
+
+packages:
+  base: !include ../MSR-1.yaml

--- a/Integrations/ESPHome/beta-channel/MSR-1_BLE.yaml
+++ b/Integrations/ESPHome/beta-channel/MSR-1_BLE.yaml
@@ -1,0 +1,9 @@
+# Beta-channel build of MSR-1_BLE.yaml: the identical image except the Firmware
+# Channel select defaults to "Beta" on first boot, so firmware obtained from
+# the beta channel keeps tracking it. Built by build-beta.yml only; the
+# stable (GitHub Pages) builds use MSR-1_BLE.yaml directly.
+substitutions:
+  firmware_channel_default: "Beta"
+
+packages:
+  base: !include ../MSR-1_BLE.yaml


### PR DESCRIPTION
Version: 26.7.8.4

## What does this implement/fix?

A fresh flash has no stored channel preference, so the Firmware Channel select fell back to "Stable" even on firmware obtained from the beta channel - and the update entity then offered the older stable build as a "downgrade".

- `initial_option` becomes a substitution (`firmware_channel_default`, still `"Stable"` - stable/Pages builds are byte-identical to before).
- New 8-line `beta-channel/` wrapper yamls override it to `"Beta"`, same override pattern the repos already use for variant wrappers; `build-beta.yml` now builds the wrappers.
- Net effect: firmware downloaded from the beta channel (or flashed from the `beta-fw` release page) boots with the select on Beta and keeps tracking beta. `restore_value` semantics unchanged - the default only applies when no stored choice exists.

Wrapper renders verified locally: base `MSR-1.yaml` -> `initial_option: Stable`, `beta-channel/MSR-1.yaml` -> `initial_option: Beta`. All five configs validate on ESPHome 2026.6.4.

(26.7.8.3 is held by open PR #90; whichever merges second takes a trivial version rebase.)

## Types of changes

- [x] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:

  - [ ] The code change has been tested and works locally
  - [x] The code change has not yet been tested

If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added beta-channel firmware variants for standard and BLE device builds.
  * Firmware now starts with the appropriate update channel selected by default on first boot.

* **Bug Fixes**
  * Updated the device configuration version and aligned the initial firmware channel selection with the new default setting.
  * Beta CI builds now use the beta-specific firmware definitions, while stable publishing remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->