### PR TITLE
Fix beta manifest fetch and guard force-install against stale manifests

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  version:  "26.7.8.5"
+  version:  "26.7.8.6"
   device_description: ${name} made by Apollo Automation - version ${version}.
   # Default OTA password. Override in your device YAML by re-declaring
   # `substitutions: { ota_password: !secret <name>_ota_password }` so each
@@ -707,9 +707,23 @@ button:
       # condition to wait on (update.is_available stays false for same-version
       # variant switches), so give it a fixed window like R_PRO-1/CAST-1 do.
       - delay: 5s
-      - update.perform:
-          id: update_http_request
-          force_update: true
+      # perform() installs whatever manifest was last fetched successfully -
+      # if the refresh above failed (e.g. network blip), that can be the OTHER
+      # channel's image. Refuse instead of installing the wrong firmware.
+      - lambda: |-
+          const bool want_beta = id(firmware_channel).current_option() == "Beta";
+          const bool want_ble  = id(firmware_ble).current_option() == "Enabled";
+          const std::string &url = id(update_http_request).update_info.firmware_url;
+          const bool url_beta = url.find("/releases/download/") != std::string::npos;
+          const bool url_ble  = url.find("ble") != std::string::npos;
+          if (url.empty() || url_beta != want_beta || url_ble != want_ble) {
+            ESP_LOGE("firmware",
+                     "Cached manifest (%s) does not match the selected channel/variant - "
+                     "the manifest refresh likely failed. Not installing; press again.",
+                     url.empty() ? "<none>" : url.c_str());
+          } else {
+            id(update_http_request).perform(true);
+          }
       # Only reached if the update did not start (e.g. manifest unreachable).
       - lambda: |-
           #ifdef USE_ESP32_BLE

--- a/Integrations/ESPHome/MSR-1.yaml
+++ b/Integrations/ESPHome/MSR-1.yaml
@@ -47,6 +47,10 @@ web_server:
 
 http_request:
   verify_ssl: true
+  # GitHub release-asset downloads answer with a redirect whose signed
+  # Location header exceeds the 512-byte default and fails with
+  # "HTTP_CLIENT: Out of buffer".
+  buffer_size_rx: 2048
 
 safe_mode:
 

--- a/Integrations/ESPHome/MSR-1_BLE.yaml
+++ b/Integrations/ESPHome/MSR-1_BLE.yaml
@@ -47,6 +47,10 @@ bluetooth_proxy:
 
 http_request:
   verify_ssl: true
+  # GitHub release-asset downloads answer with a redirect whose signed
+  # Location header exceeds the 512-byte default and fails with
+  # "HTTP_CLIENT: Out of buffer".
+  buffer_size_rx: 2048
 
 safe_mode:
 

--- a/Integrations/ESPHome/MSR-1_Factory.yaml
+++ b/Integrations/ESPHome/MSR-1_Factory.yaml
@@ -45,6 +45,10 @@ ota:
 
 http_request:
   verify_ssl: true
+  # GitHub release-asset downloads answer with a redirect whose signed
+  # Location header exceeds the 512-byte default and fails with
+  # "HTTP_CLIENT: Out of buffer".
+  buffer_size_rx: 2048
 
 safe_mode:
 


### PR DESCRIPTION
Version: 26.7.8.6

## What does this implement/fix?

Hardware testing surfaced two OTA bugs that combined into WiFi-eating downgrades:

- **Beta manifest fetches always failed.** GitHub release-asset URLs answer with a redirect whose signed `Location` header exceeds `esp_http_client`'s 512-byte default rx buffer (`HTTP_CLIENT: Out of buffer`). Fixed with `buffer_size_rx: 2048` on all images. Without this, beta-channel devices could neither refresh their manifest nor be offered updates.
- **The Firmware Update button could install the wrong channel's image.** `update.perform(force)` uses whatever manifest was last fetched successfully; with the fetch failing, pressing the button on Beta silently installed the cached *Stable* manifest - downgrading to the old pre-feature image, which also wiped saved settings (WiFi credentials included) on boot. The button now verifies the cached manifest URL matches the selected channel *and* variant before performing, and refuses with a clear log line otherwise.

Log evidence from the failing device:

```
[E] Failed to fetch manifest from .../releases/download/beta-fw/manifest-standard.json
[I] Starting update
[I] Connecting to: https://apolloautomation.github.io/MSR-1/firmware/apollo-msr-1-esp32c3.ota.bin
```

All five configs validate on ESPHome 2026.6.4. Needs a hardware re-test of the Beta force-install path once merged.

## Types of changes

- [x] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:

  - [ ] The code change has been tested and works locally
  - [x] The code change has not yet been tested

If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved firmware update reliability by preventing installs when the available update appears to be from a different release channel or device variant.
  * Increased network response buffer sizes to avoid download failures during large redirect responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->