### PR TITLE
Raise http_request rx buffer to 5120 for GitHub's CSP header

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  version:  "26.7.8.6"
+  version:  "26.7.8.7"
   device_description: ${name} made by Apollo Automation - version ${version}.
   # Default OTA password. Override in your device YAML by re-declaring
   # `substitutions: { ota_password: !secret <name>_ota_password }` so each

--- a/Integrations/ESPHome/MSR-1.yaml
+++ b/Integrations/ESPHome/MSR-1.yaml
@@ -47,10 +47,10 @@ web_server:
 
 http_request:
   verify_ssl: true
-  # GitHub release-asset downloads answer with a redirect whose signed
-  # Location header exceeds the 512-byte default and fails with
-  # "HTTP_CLIENT: Out of buffer".
-  buffer_size_rx: 2048
+  # GitHub release-asset downloads answer with a redirect carrying a
+  # ~3.6 KB Content-Security-Policy header; each header line must fit
+  # this buffer or the request fails with "HTTP_CLIENT: Out of buffer".
+  buffer_size_rx: 5120
 
 safe_mode:
 

--- a/Integrations/ESPHome/MSR-1_BLE.yaml
+++ b/Integrations/ESPHome/MSR-1_BLE.yaml
@@ -47,10 +47,10 @@ bluetooth_proxy:
 
 http_request:
   verify_ssl: true
-  # GitHub release-asset downloads answer with a redirect whose signed
-  # Location header exceeds the 512-byte default and fails with
-  # "HTTP_CLIENT: Out of buffer".
-  buffer_size_rx: 2048
+  # GitHub release-asset downloads answer with a redirect carrying a
+  # ~3.6 KB Content-Security-Policy header; each header line must fit
+  # this buffer or the request fails with "HTTP_CLIENT: Out of buffer".
+  buffer_size_rx: 5120
 
 safe_mode:
 

--- a/Integrations/ESPHome/MSR-1_Factory.yaml
+++ b/Integrations/ESPHome/MSR-1_Factory.yaml
@@ -45,10 +45,10 @@ ota:
 
 http_request:
   verify_ssl: true
-  # GitHub release-asset downloads answer with a redirect whose signed
-  # Location header exceeds the 512-byte default and fails with
-  # "HTTP_CLIENT: Out of buffer".
-  buffer_size_rx: 2048
+  # GitHub release-asset downloads answer with a redirect carrying a
+  # ~3.6 KB Content-Security-Policy header; each header line must fit
+  # this buffer or the request fails with "HTTP_CLIENT: Out of buffer".
+  buffer_size_rx: 5120
 
 safe_mode:
 


### PR DESCRIPTION
Version: 26.7.8.7

## What does this implement/fix?

Follow-up to #93: the 2048-byte rx buffer is still too small. The redirect on GitHub release-asset downloads carries a **~3.6 KB Content-Security-Policy header line**, and `esp_http_client` requires each header line to fit the rx buffer - so beta manifest fetches kept failing with `HTTP_CLIENT: Out of buffer` even on 26.7.8.6 (confirmed on hardware; measured `Content-Security-Policy` at 3585 bytes today). Raised to 5120 for headroom.

Silver lining from the same hardware test: #93's manifest guard worked - after the failed fetch it refused to install, so no wrong-channel downgrade and no lost WiFi this time.

## Types of changes

- [x] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:

  - [ ] The code change has been tested and works locally
  - [x] The code change has not yet been tested

If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased network receive buffering for several device configurations to better handle larger download redirects and response headers, reducing “out of buffer” failures.
  * Updated one integration version to the latest release number.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->