### PR TITLE
Set http_request buffer_size_tx: 2048 - the real Out of buffer fix

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  version:  "26.7.8.7"
+  version:  "26.7.8.8"
   device_description: ${name} made by Apollo Automation - version ${version}.
   # Default OTA password. Override in your device YAML by re-declaring
   # `substitutions: { ota_password: !secret <name>_ota_password }` so each

--- a/Integrations/ESPHome/MSR-1.yaml
+++ b/Integrations/ESPHome/MSR-1.yaml
@@ -51,6 +51,10 @@ http_request:
   # ~3.6 KB Content-Security-Policy header; each header line must fit
   # this buffer or the request fails with "HTTP_CLIENT: Out of buffer".
   buffer_size_rx: 5120
+  # The redirect target is a signed URL with a ~850-char query string; the
+  # follow-up request line must fit the TX buffer or esp_http_client_open
+  # fails with "Out of buffer" before sending anything.
+  buffer_size_tx: 2048
 
 safe_mode:
 

--- a/Integrations/ESPHome/MSR-1_BLE.yaml
+++ b/Integrations/ESPHome/MSR-1_BLE.yaml
@@ -51,6 +51,10 @@ http_request:
   # ~3.6 KB Content-Security-Policy header; each header line must fit
   # this buffer or the request fails with "HTTP_CLIENT: Out of buffer".
   buffer_size_rx: 5120
+  # The redirect target is a signed URL with a ~850-char query string; the
+  # follow-up request line must fit the TX buffer or esp_http_client_open
+  # fails with "Out of buffer" before sending anything.
+  buffer_size_tx: 2048
 
 safe_mode:
 

--- a/Integrations/ESPHome/MSR-1_Factory.yaml
+++ b/Integrations/ESPHome/MSR-1_Factory.yaml
@@ -49,6 +49,10 @@ http_request:
   # ~3.6 KB Content-Security-Policy header; each header line must fit
   # this buffer or the request fails with "HTTP_CLIENT: Out of buffer".
   buffer_size_rx: 5120
+  # The redirect target is a signed URL with a ~850-char query string; the
+  # follow-up request line must fit the TX buffer or esp_http_client_open
+  # fails with "Out of buffer" before sending anything.
+  buffer_size_tx: 2048
 
 safe_mode:
 


### PR DESCRIPTION
Version: 26.7.8.8

## What does this implement/fix?

Third time's the charm on `HTTP_CLIENT: Out of buffer`, and this one is confirmed against the IDF source rather than inferred: `esp_http_client` emits "Out of buffer" from **request-line composition** (`http_client_prepare_first_line` in `esp_http_client.c`) - `GET <path>?<query>` must fit **`buffer_size_tx`**. GitHub's release-asset redirect targets a signed URL with a ~850-character query string, so the follow-up request could never be built in the 512-byte default TX buffer. That's why the failure is at `esp_http_client_open` (before anything is sent), and why raising the RX buffer (#93, #94) didn't help - the error was reproduced unchanged on hardware running 26.7.8.7.

`buffer_size_tx: 2048` on all images. The RX bump from #94 stays (the first hop's 3.6 KB CSP header is still real).

## Types of changes

- [x] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:

  - [ ] The code change has been tested and works locally
  - [x] The code change has not yet been tested

If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

🤖 Generated with [Claude Code](https://claude.com/claude-code)
