### PR TITLE
Cleanup: remove vestigial ble_firmware sub; fix build.yml device-name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       id-token: write
       pull-requests: write
     with:
-      device-name: msr-2
+      device-name: msr-1
       # MSR-1.yaml is the end-user image served at firmware/ (OTA updates). The Factory image (improv +
       # factory test) is only used for first flashes via the web installer.
       yaml-files: |

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -5,10 +5,6 @@ substitutions:
   # `substitutions: { ota_password: !secret <name>_ota_password }` so each
   # device on your network uses a unique secret instead of the shared default.
   ota_password: "apolloautomation"
-  # Firmware variant identity: overridden to "true" by MSR-1_BLE.yaml. Seeds
-  # the Bluetooth Proxy select on boot so it self-corrects to what is
-  # actually running after a failed or abandoned switch.
-  ble_firmware: "false"
   # Default update channel on first boot (no stored user choice yet, i.e. a
   # fresh flash). The beta-channel builds override this to "Beta" (see
   # Integrations/ESPHome/beta-channel/) so firmware obtained from the beta

--- a/Integrations/ESPHome/MSR-1_BLE.yaml
+++ b/Integrations/ESPHome/MSR-1_BLE.yaml
@@ -1,5 +1,4 @@
 substitutions:
-  ble_firmware: "true"
   # Legacy BLE devices keep updating from the firmware-ble manifest.
   ota_stable_manifest: "https://apolloautomation.github.io/MSR-1/firmware-ble/manifest.json"
   ota_beta_manifest: "https://github.com/ApolloAutomation/MSR-1/releases/download/beta-fw/manifest-ble.json"


### PR DESCRIPTION
<!--
From Core.yaml. Should match date YY.MM.DD.# ( Usually # is 1 )
-->
Version: 26.7.9.1 (no change — no-publish cleanup)

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## What does this implement/fix?

Small cleanup after the unified-firmware change (#100):

- **Remove the vestigial `ble_firmware` substitution.** Nothing reads `${ble_firmware}` anymore — the runtime "Bluetooth Proxy" switch replaced the old `firmware_ble` manifest selector, and the on-boot lambda that consumed it is gone. Removed from `Core.yaml` and `MSR-1_BLE.yaml`. Compiled output is identical.
- **Fix `device-name` in `build.yml`** (`msr-2` → `msr-1`). It's a required-but-unused input in the shared `ApolloAutomation/Workflows` build workflow (declared, never consumed), so this is a no-op correctness fix — the wrong value never affected any published path.

No firmware behavior change; does not publish.

## Types of changes
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [x] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:
<!--
  Put an x in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

  - [x] The code change has been tested and works locally
  - [ ] The code change has not yet been tested

If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

🤖 Generated with [Claude Code](https://claude.com/claude-code)
