### PR TITLE
Consolidate http_request block into Core.yaml

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -64,6 +64,17 @@ web_server:
   port: 80
   version: 3
 
+http_request:
+  verify_ssl: true
+  # GitHub release-asset downloads answer with a redirect carrying a
+  # ~3.6 KB Content-Security-Policy header; each header line must fit
+  # this buffer or the request fails with "HTTP_CLIENT: Out of buffer".
+  buffer_size_rx: 5120
+  # The redirect target is a signed URL with a ~850-char query string; the
+  # follow-up request line must fit the TX buffer or esp_http_client_open
+  # fails with "Out of buffer" before sending anything.
+  buffer_size_tx: 2048
+
 api:
   encryption:
   on_client_connected:

--- a/Integrations/ESPHome/MSR-1.yaml
+++ b/Integrations/ESPHome/MSR-1.yaml
@@ -45,17 +45,6 @@ web_server:
   port: 80
   version: 3
 
-http_request:
-  verify_ssl: true
-  # GitHub release-asset downloads answer with a redirect carrying a
-  # ~3.6 KB Content-Security-Policy header; each header line must fit
-  # this buffer or the request fails with "HTTP_CLIENT: Out of buffer".
-  buffer_size_rx: 5120
-  # The redirect target is a signed URL with a ~850-char query string; the
-  # follow-up request line must fit the TX buffer or esp_http_client_open
-  # fails with "Out of buffer" before sending anything.
-  buffer_size_tx: 2048
-
 safe_mode:
 
 update:

--- a/Integrations/ESPHome/MSR-1_BLE.yaml
+++ b/Integrations/ESPHome/MSR-1_BLE.yaml
@@ -45,17 +45,6 @@ wifi:
   ap:
     ssid: "Apollo MSR1 Hotspot"
 
-http_request:
-  verify_ssl: true
-  # GitHub release-asset downloads answer with a redirect carrying a
-  # ~3.6 KB Content-Security-Policy header; each header line must fit
-  # this buffer or the request fails with "HTTP_CLIENT: Out of buffer".
-  buffer_size_rx: 5120
-  # The redirect target is a signed URL with a ~850-char query string; the
-  # follow-up request line must fit the TX buffer or esp_http_client_open
-  # fails with "Out of buffer" before sending anything.
-  buffer_size_tx: 2048
-
 safe_mode:
 
 update:

--- a/Integrations/ESPHome/MSR-1_Factory.yaml
+++ b/Integrations/ESPHome/MSR-1_Factory.yaml
@@ -43,17 +43,6 @@ ota:
   - platform: http_request
     id: ota_managed
 
-http_request:
-  verify_ssl: true
-  # GitHub release-asset downloads answer with a redirect carrying a
-  # ~3.6 KB Content-Security-Policy header; each header line must fit
-  # this buffer or the request fails with "HTTP_CLIENT: Out of buffer".
-  buffer_size_rx: 5120
-  # The redirect target is a signed URL with a ~850-char query string; the
-  # follow-up request line must fit the TX buffer or esp_http_client_open
-  # fails with "Out of buffer" before sending anything.
-  buffer_size_tx: 2048
-
 safe_mode:
 
 update:


### PR DESCRIPTION
<!--
From Core.yaml. Should match date YY.MM.DD.# ( Usually # is 1 )
-->
Version: 26.7.9.1 (no change — no-publish consolidation)

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## What does this implement/fix?

Moves the `http_request:` component config — `verify_ssl` plus the OTA-download `buffer_size_rx: 5120` / `buffer_size_tx: 2048` (sized for GitHub release-asset headers/URLs) — into `Core.yaml`, since it was duplicated **identically** across `MSR-1.yaml`, `MSR-1_BLE.yaml`, and `MSR-1_Factory.yaml`.

One source of truth for the buffer sizes. The `ota:` and `update:` **platforms** that use `http_request` stay in the variants (they reference the shared component). Compiled output is unchanged.

## Types of changes
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [x] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:
<!--
  Put an x in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

  - [x] The code change has been tested and works locally
  - [ ] The code change has not yet been tested

If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for ESPHome HTTP downloads by enabling stricter SSL verification and larger request buffers in the core configuration.
  * Removed custom HTTP request tuning from several device-specific configurations so they now use the default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->