### PR TITLE
Remove unneeded pre-OTA BLE disable from Firmware Update

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -710,13 +710,6 @@ button:
     entity_category: "config"
     on_press:
       - logger.log: "Applying firmware update for the selected channel"
-      # Free RAM for the TLS download by dropping the BLE stack. On success the
-      # device reboots and the Bluetooth Proxy switch restores its scan state;
-      # on the not-started path below we re-enable and re-apply the switch.
-      - lambda: |-
-          #ifdef USE_ESP32_BLE
-          if (esp32_ble::global_ble) esp32_ble::global_ble->disable();
-          #endif
       - delay: 3s
       - script.execute: apply_ota_source
       - script.wait: apply_ota_source
@@ -724,20 +717,6 @@ button:
       # (update.is_available stays false for same-version switches).
       - delay: 5s
       - lambda: id(update_http_request).perform(true);
-      # Reached only if the update did not start. Restore the BLE stack and the
-      # Bluetooth Proxy switch's scan state.
-      - lambda: |-
-          #ifdef USE_ESP32_BLE
-          if (esp32_ble::global_ble) esp32_ble::global_ble->enable();
-          #endif
-      - if:
-          condition:
-            switch.is_on: bluetooth_proxy_switch
-          then:
-            - esp32_ble_tracker.start_scan:
-                continuous: true
-          else:
-            - esp32_ble_tracker.stop_scan:
 
 
 switch:


### PR DESCRIPTION
<!--
From Core.yaml. Should match date YY.MM.DD.# ( Usually # is 1 )
-->
Version: 26.7.9.1 (no change — part of the single release)

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## What does this implement/fix?

Removes the logic that dropped the BLE stack before an OTA and re-enabled/re-applied the scan afterward, from the **Firmware Update** button.

Verified on hardware: the unified build (~21% RAM at rest, ~260 KB free) completes the TLS firmware download with the Bluetooth proxy still active, so freeing RAM by disabling BLE first isn't needed. The proxy now stays up through the update — simpler flow, no BLE interruption.

Kept the two `delay` steps (manifest-fetch timing). The `delay: 3s` previously let the BLE disable settle; it's a harmless brief pause now — happy to drop it too if you'd prefer.

## Types of changes
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:
<!--
  Put an x in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

  - [x] The code change has been tested and works locally
  - [ ] The code change has not yet been tested

If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

🤖 Generated with [Claude Code](https://claude.com/claude-code)
