### PR TITLE
Drop redundant bluetooth_proxy active: true (now the default)

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -52,7 +52,6 @@ esp32_ble_tracker:
     continuous: true
 
 bluetooth_proxy:
-  active: true
 
 captive_portal:
 


### PR DESCRIPTION
<!--
From Core.yaml. Should match date YY.MM.DD.# ( Usually # is 1 )
-->
Version: 26.7.9.1 (no change — no-publish simplification)

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## What does this implement/fix?

Drops the redundant `active: true` from `bluetooth_proxy`, leaving the bare `bluetooth_proxy:` line.

The [`bluetooth_proxy` component](https://esphome.io/components/bluetooth_proxy/) now **enables active connections by default**, and Home Assistant manages active-vs-passive dynamically — it opens an active connection only when an integration needs one, and stays passive otherwise. So `active: true` was redundant with the current default; removing it is behaviorally identical (same compiled value).

## Types of changes
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [x] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:
<!--
  Put an x in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

  - [x] The code change has been tested and works locally
  - [ ] The code change has not yet been tested

If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

🤖 Generated with [Claude Code](https://claude.com/claude-code)
