### PR TITLE
Keep Bluetooth Proxy on for legacy BLE builds

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  version:  "26.7.29.1"
+  version:  "26.8.18.1"
   device_description: ${name} made by Apollo Automation - version ${version}.
   # Default OTA password. Override in your device YAML by re-declaring
   # `substitutions: { ota_password: !secret <name>_ota_password }` so each

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  version:  "26.7.9.1"
+  version:  "26.7.29.1"
   device_description: ${name} made by Apollo Automation - version ${version}.
   # Default OTA password. Override in your device YAML by re-declaring
   # `substitutions: { ota_password: !secret <name>_ota_password }` so each
@@ -20,6 +20,12 @@ substitutions:
   ota_stable_manifest: "${stable_manifest_base}/firmware/manifest.json"
   ota_beta_manifest: "${beta_manifest_base}/manifest-standard.json"
 
+  # Bluetooth Proxy switch state on a device with no stored preference yet
+  # (first boot after this switch was added, or after a factory reset). The
+  # unified image ships the proxy off; MSR-1_BLE.yaml overrides this to ON so
+  # legacy BLE devices keep proxying instead of going quiet after an update.
+  bluetooth_proxy_restore_mode: RESTORE_DEFAULT_OFF
+
 esphome:
   # List form so package merging concatenates with each variant's own on_boot
   # entries (mapping form would be replaced by the variant's block instead).
@@ -28,7 +34,7 @@ esphome:
       then:
         - script.execute: apply_ota_source
     # Re-apply the Bluetooth Proxy switch after all components set up, so BLE
-    # scanning matches the persisted switch (proxy stays off by default).
+    # scanning matches the switch state restored from flash.
     - priority: -300
       then:
         - if:
@@ -755,7 +761,7 @@ switch:
     id: bluetooth_proxy_switch
     icon: mdi:bluetooth
     entity_category: "config"
-    restore_mode: RESTORE_DEFAULT_OFF
+    restore_mode: ${bluetooth_proxy_restore_mode}
     optimistic: true
     on_turn_on:
       - esp32_ble_tracker.start_scan:

--- a/Integrations/ESPHome/MSR-1_BLE.yaml
+++ b/Integrations/ESPHome/MSR-1_BLE.yaml
@@ -3,6 +3,10 @@ substitutions:
   ota_stable_manifest: "https://apolloautomation.github.io/MSR-1/firmware-ble/manifest.json"
   ota_beta_manifest: "https://github.com/ApolloAutomation/MSR-1/releases/download/beta-fw/manifest-ble.json"
 
+  # Legacy BLE devices proxied unconditionally before the Bluetooth Proxy
+  # switch existed, so default it on rather than dropping the proxy on update.
+  bluetooth_proxy_restore_mode: RESTORE_DEFAULT_ON
+
 esphome:
   name: apollo-msr-1
   friendly_name: Apollo Multisensor Mk1 (MSR-1)


### PR DESCRIPTION
Version: 26.7.29.1

## What does this implement/fix?

The Bluetooth Proxy switch does restore from flash, but the `_OFF` half of
`RESTORE_DEFAULT_OFF` only decides the boot where nothing is stored yet, which is
the first boot after the switch shipped. `MSR-1_BLE.yaml` inherited that mode from
Core, so a legacy BLE device that had always proxied comes up with the proxy off
after updating and stays that way until the user finds the switch. Reported in ApolloAutomation/MSR-2#92.

Core now reads the mode from a `bluetooth_proxy_restore_mode` substitution
defaulting to `RESTORE_DEFAULT_OFF`, and `MSR-1_BLE.yaml` overrides it to
`RESTORE_DEFAULT_ON`, the same override pattern that file already uses for its OTA
manifest URLs. The unified image is unchanged, and a user's saved choice still wins
on every later boot.

Validated with `esphome config` on 2026.7.2 across `MSR-1.yaml`, `MSR-1_BLE.yaml`
and `MSR-1_Factory.yaml`. Rendered switch: standard `RESTORE_DEFAULT_OFF`, BLE
`RESTORE_DEFAULT_ON`.

Matching PRs go to AIR-1, MSR-2 and MTR-1, which carry the identical switch and BLE variant.

## Types of changes

- [x] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish

## Checklist / Checklijst:

  - [x] The code change has been tested and works locally
  - [ ] The code change has not yet been tested

If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable Bluetooth Proxy restoration behavior.
  * Bluetooth Proxy can restore its configured state after startup, factory reset, or firmware updates.
  * Legacy BLE device support remains enabled by default on MSR-1 devices during updates.
* **Improvements**
  * BLE scanning now follows the restored Bluetooth Proxy state, improving consistency after restart or reset.
  * Updated firmware to version 26.8.18.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->